### PR TITLE
chore: reduce container size

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,9 @@
-FROM python:3.11.4
+FROM python:3.11.4-alpine3.18
 
-RUN apt update && apt install -y gettext libgettextpo-dev && pip install --upgrade pip && pip install -U poetry
+RUN apk update && apk add --no-cache gettext libintl && pip install -U poetry
 RUN poetry config virtualenvs.create false
 
 WORKDIR /code
 
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --only main
-
-COPY . .
-
-RUN ./setup.sh

--- a/development.yml
+++ b/development.yml
@@ -49,7 +49,7 @@ services:
     build:
       context: $BACKEND_DIR
       dockerfile: Dockerfile
-    command: /bin/bash -c "./setup.sh && python manage.py runsslserver 192.168.90.2:8080"
+    command: sh -c "./setup.sh && python manage.py runsslserver 192.168.90.2:8080"
     expose:
       - 8080
     volumes:
@@ -60,7 +60,7 @@ services:
     container_name: celery
     build:
       context: $BACKEND_DIR
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
     command: celery -A ypovoli worker -l DEBUG
     volumes:
       - ${BACKEND_DIR}:/code
@@ -74,7 +74,7 @@ services:
     build:
       context: $FRONTEND_DIR
       dockerfile: Dockerfile.dev
-    command: bash -c "npm install && npm run host"
+    command: sh -c "npm install && npm run host"
     expose:
       - 5173
     volumes:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.17.1-alpine3.17
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:18 as build-stage
+FROM node:18.17.1-alpine3.17 as build-stage
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/production.yml
+++ b/production.yml
@@ -64,7 +64,7 @@ services:
     build:
       context: $BACKEND_DIR
       dockerfile: Dockerfile
-    command: bash -c "./setup.sh && gunicorn --config gunicorn_config.py ypovoli.wsgi:application"
+    command: sh -c "./setup.sh && gunicorn --config gunicorn_config.py ypovoli.wsgi:application"
     expose:
       - 8080
     depends_on:
@@ -88,7 +88,7 @@ services:
     container_name: celery
     build:
       context: $BACKEND_DIR
-      dockerfile: Dockerfile.prod
+      dockerfile: Dockerfile
     command: celery -A ypovoli worker -l ERROR
     volumes:
       - ${BACKEND_DIR}:/code

--- a/test.sh
+++ b/test.sh
@@ -85,6 +85,8 @@ else
     vitest_exit=$?
 fi
 
+exit_code=0
+
 echo "-----------------"
 if [ $cypress_exit -ne 0 ] || [ $vitest_exit -ne 0 ] || [ $django_exit -ne 0 ]; then
     echo "Tests failed:"
@@ -97,11 +99,7 @@ if [ $cypress_exit -ne 0 ] || [ $vitest_exit -ne 0 ] || [ $django_exit -ne 0 ]; 
     if [ $django_exit -ne 0 ]; then
         echo "  - Django"
     fi
-    echo "-----------------"
-    echo "Cleaning up..."
-    docker-compose -f test.yml down
-    echo "Done."
-    exit 1
+    exit_code=1
 else
     echo "All tests passed!"
 fi
@@ -109,8 +107,8 @@ echo "-----------------"
 
 echo "Cleaning up..."
 
-docker-compose -f test.yml down
+docker-compose -f test.yml down --rmi all
 
 echo "Done."
 
-exit 0
+exit $exit_code

--- a/test.yml
+++ b/test.yml
@@ -12,12 +12,12 @@ networks:
 
 ############################# EXTENSIONS
 
-x-common-keys-selab: &common-keys-selab
+x-common-keys-selab_test: &common-keys-selab_test
   networks:
     - test_selab_network
   security_opt:
     - no-new-privileges:true
-  restart: unless-stopped
+  restart: "no"
   environment:
     TZ: $TZ
     PUID: $PUID
@@ -29,7 +29,7 @@ x-common-keys-selab: &common-keys-selab
 
 services:
   test_nginx:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     image: nginx:latest
     container_name: test_nginx
     expose:
@@ -44,24 +44,24 @@ services:
       - test_frontend
 
   test_backend:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     container_name: test_backend
     build:
       context: $BACKEND_DIR
       dockerfile: Dockerfile
-    command: /bin/bash -c "./setup.sh && python manage.py runsslserver 192.168.91.2:8080"
+    command: sh -c "./setup.sh && python manage.py runsslserver 192.168.91.2:8080"
     expose:
       - 8080
     volumes:
       - $BACKEND_DIR:/code
 
   test_celery:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     container_name: test_celery
     build:
       context: $BACKEND_DIR
       dockerfile: Dockerfile
-    command: celery -A ypovoli worker -l DEBUG
+    command: sh -c "poetry install && celery -A ypovoli worker -l DEBUG"
     volumes:
       - $BACKEND_DIR:/code
     depends_on:
@@ -69,12 +69,12 @@ services:
       - test_redis
 
   test_frontend:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     container_name: test_frontend
     build:
       context: $FRONTEND_DIR
       dockerfile: Dockerfile.dev
-    command: bash -c "npm install && npm run host"
+    command: sh -c "npm install && npm run host"
     expose:
       - 5173
     volumes:
@@ -83,7 +83,7 @@ services:
       - test_backend
 
   test_redis:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     container_name: test_redis
     image: redis:latest
     networks:
@@ -96,12 +96,9 @@ services:
       - ${DATA_DIR}/redis:/data
 
   test_cypress:
-    <<: *common-keys-selab
+    <<: *common-keys-selab_test
     container_name: test_cypress
     image: cypress/included:cypress-12.17.3-node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
-    restart: "no"
     working_dir: /e2e
     volumes:
       - ${FRONTEND_DIR}:/e2e
-    extra_hosts:
-      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
- Remove images after building them in test.sh
- Reduce overal container sizes

Backend 1.33 GB -> 314 MB
Frontend 2.36 GB -> 1.46 GB
Celery 1.33 GB -> 314 MB

This will speed up the downloading process when building a clean image