### PR TITLE
fix: cypress tests

### DIFF
--- a/backend/ypovoli/settings.py
+++ b/backend/ypovoli/settings.py
@@ -46,8 +46,8 @@ SECRET_KEY = environ.get("DJANGO_SECRET_KEY", "lnZZ2xHc6HjU5D85GDE3Nnu4CJsBnm")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = environ.get("DJANGO_DEBUG", "False").lower() in ["true", "1", "t"]
 DOMAIN_NAME = environ.get("DJANGO_DOMAIN_NAME", "localhost")
-ALLOWED_HOSTS = [DOMAIN_NAME]
-CSRF_TRUSTED_ORIGINS = ["https://" + DOMAIN_NAME]
+ALLOWED_HOSTS = [DOMAIN_NAME, "nginx"]
+CSRF_TRUSTED_ORIGINS = ["https://" + DOMAIN_NAME, "https://nginx"]
 
 # Application definition
 INSTALLED_APPS = [

--- a/frontend/Dockerfile.cypress
+++ b/frontend/Dockerfile.cypress
@@ -1,0 +1,8 @@
+ARG CHROME_VERSION="114.0.5735.133-1"
+ARG NODE_VERSION="18.17.1"
+
+FROM cypress/factory
+
+WORKDIR /e2e
+
+RUN npm install --save-dev cypress

--- a/frontend/Dockerfile.cypress
+++ b/frontend/Dockerfile.cypress
@@ -2,7 +2,3 @@ ARG CHROME_VERSION="114.0.5735.133-1"
 ARG NODE_VERSION="18.17.1"
 
 FROM cypress/factory
-
-WORKDIR /e2e
-
-RUN npm install --save-dev cypress

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
     e2e: {
-        baseUrl: 'http://nginx',
+        baseUrl: 'https://nginx',
         specPattern: 'src/test/e2e/**/*.cy.{js,jsx,ts,tsx}',
     },
 });

--- a/test.sh
+++ b/test.sh
@@ -92,7 +92,7 @@ fi
 exit_code=0
 
 echo "-----------------"
-if [ $vitest_exit -ne 0 ] || [ $django_exit -ne 0 ]; then
+if [ $cypress_exit -ne 0 ] || [ $vitest_exit -ne 0 ] || [ $django_exit -ne 0 ]; then
     echo "Tests failed:"
     if [ $cypress_exit -ne 0 ]; then
         echo "  - Cypress"

--- a/test.yml
+++ b/test.yml
@@ -52,6 +52,8 @@ services:
     command: sh -c "./setup.sh && python manage.py runsslserver 0.0.0.0:8000"
     volumes:
       - $BACKEND_DIR:/code
+    depends_on:
+      - redis
 
   celery:
     <<: *common-keys-selab_test
@@ -89,7 +91,12 @@ services:
   cypress:
     <<: *common-keys-selab_test
     container_name: cypress
-    image: cypress/included:cypress-12.17.3-node-18.16.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+    build:
+      context: $FRONTEND_DIR
+      dockerfile: Dockerfile.cypress
+    command: "npm run cypress:test"
     working_dir: /e2e
     volumes:
       - ${FRONTEND_DIR}:/e2e
+    depends_on:
+      - frontend

--- a/test.yml
+++ b/test.yml
@@ -94,9 +94,10 @@ services:
     build:
       context: $FRONTEND_DIR
       dockerfile: Dockerfile.cypress
-    command: "npm run cypress:test"
+    command: sh -c "npm install && npm run cypress:test"
     working_dir: /e2e
     volumes:
       - ${FRONTEND_DIR}:/e2e
+      - /e2e/node_modules
     depends_on:
       - frontend


### PR DESCRIPTION
Fixes the cypress tests
Reduced image size of cypress from 2.7 GB to 1.0 GB.
Get ready to get bombarded by logs when building the image.

Closes #405 